### PR TITLE
Update mod team alumni padding to for screens larger than 1680px

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3219,7 +3219,7 @@
 	}
 
 		.wrapper > .inner {
-			padding: 5em 5em 3em 5em ;
+			padding: 5em 5em 3em 22em ;
 			max-width: 100%;
 			width: 75em;
 		}


### PR DESCRIPTION
The mod team alumni div was still positioned incorrectly for me with a browser window larger than 1680px. This changes the rule for `.wrapper > .inner`, so that screens larger than a max-width of 1680px also have the padding adjusted. As far as I can tell this shouldn't affect smaller screen sizes, since those are taken care of by the other `media` rules. Similar to #15.

**Current Site**
![https://i.imgur.com/dem4NwS.png](https://i.imgur.com/dem4NwS.png)

**Proposed Revision in DevTools**
![https://i.imgur.com/ep2Hu0s.png](https://i.imgur.com/ep2Hu0s.png)